### PR TITLE
Get rid of MD checkboxes to avoid GH to have them as PR tasks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,11 +13,12 @@
 
 <!-- If you are making a front-end change, specify which browser/device/OS you used to test your changes -->
 
-- [ ] Not a front-end change
-- [ ] I tested my changes on a Desktop Browser(s)
-- [ ] I tested my changes on a Mobile web browser(s)
-<!--- Ideally, specify which browser(s) and device(s) you used to test your changes 
-e.g. "Google Chrome v110.0.5481.77 on M2 Macbook Pro - macOS Version 13.0" 
+- ✅ | ❌ Not a front-end change
+- ✅ | ❌ I tested my changes on a Desktop Browser(s)
+- ✅ | ❌ I tested my changes on a Mobile web browser(s)
+
+<!--- Ideally, specify which browser(s) and device(s) you used to test your changes
+e.g. "Google Chrome v110.0.5481.77 on M2 Macbook Pro - macOS Version 13.0"
 Check the Google Chrome version with chrome://version
 
 ℹ️: ~70% of SNAP recipients have an Android device


### PR DESCRIPTION
## What
Updates PR template by having emojis instead of markdown checkboxes for front-end testing.

## Why
Having markdown checkboxes on the PR description makes them automatically tasks which may give you the impression that the PR is incomplete. There are cases where PR tasks are used as a TODO list for completing the PR changes, e.g.

<img width="470" alt="Screenshot 2023-05-04 at 10 46 35" src="https://user-images.githubusercontent.com/1004648/236286812-3c09b374-560e-4129-9973-d472af5d2190.png">


Instead of checking the boxes, you must select between  ✅ and ❌ emojis while setting up your PR. It would look something like this.

<img width="648" alt="image" src="https://user-images.githubusercontent.com/1004648/236286074-39928d1d-f765-4fc7-87aa-037f0fd81e91.png">
